### PR TITLE
Create You scared.md

### DIFF
--- a/You scared.md
+++ b/You scared.md
@@ -1,0 +1,14 @@
+Narcissists, regardless of nationality, often seek to control or dominate others as a means of maintaining their perceived superiority or self-image. In the American cultural context, this behavior may manifest as an exaggerated focus on "putting people in their place," which could mean belittling, manipulating, or asserting dominance over others. This tendency often aligns with a narcissist's need for validation, control, and power dynamics in relationships or social settings.
+
+### Possible Reasons for This Behavior:
+1. **Validation Seeking**: Narcissists may belittle others to reinforce their own superiority and gain validation from onlookers.
+2. **Control and Power**: Keeping people "in their place" allows narcissists to feel in control and maintain a hierarchical social structure that favors them.
+3. **Insecurity Masking**: Publicly asserting dominance might hide deep-seated insecurities or fears of inadequacy.
+4. **Cultural Influence**: In highly individualistic societies like the U.S., the "winner-takes-all" mentality can amplify narcissistic traits, making the need to "win" over others more pronounced.
+
+### Why Narcissists May "Love" This:
+- **Sense of Achievement**: They feel they’ve asserted their "superiority."
+- **Attention**: The act often draws attention, whether positive or negative, fulfilling their need to be noticed.
+- **Illusion of Strength**: It creates a façade of power and confidence, even if it's not genuine.
+
+If you're observing or dealing with such behaviors, it's important to set boundaries and recognize when interactions are toxic. Narcissists thrive in environments where their behavior goes unchecked, so awareness and self-protection are key.


### PR DESCRIPTION
Narcissists, regardless of nationality, often seek to control or dominate others as a means of maintaining their perceived superiority or self-image. In the American cultural context, this behavior may manifest as an exaggerated focus on "putting people in their place," which could mean belittling, manipulating, or asserting dominance over others. This tendency often aligns with a narcissist's need for validation, control, and power dynamics in relationships or social settings.

### Possible Reasons for This Behavior:
1. **Validation Seeking**: Narcissists may belittle others to reinforce their own superiority and gain validation from onlookers.
2. **Control and Power**: Keeping people "in their place" allows narcissists to feel in control and maintain a hierarchical social structure that favors them.
3. **Insecurity Masking**: Publicly asserting dominance might hide deep-seated insecurities or fears of inadequacy.
4. **Cultural Influence**: In highly individualistic societies like the U.S., the "winner-takes-all" mentality can amplify narcissistic traits, making the need to "win" over others more pronounced.

### Why Narcissists May "Love" This:
- **Sense of Achievement**: They feel they’ve asserted their "superiority."
- **Attention**: The act often draws attention, whether positive or negative, fulfilling their need to be noticed.
- **Illusion of Strength**: It creates a façade of power and confidence, even if it's not genuine.

If you're observing or dealing with such behaviors, it's important to set boundaries and recognize when interactions are toxic. Narcissists thrive in environments where their behavior goes unchecked, so awareness and self-protection are key.